### PR TITLE
Add ApiRequestLog observability stack and migrate User to UUID PK

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -68,6 +68,8 @@ UserContracts::Create.call(permitted_params(:email, :password))
 
 **Packwerk Modular Architecture** - Isolated modules in `packs/` directory (e.g., `demo_pack`, `oauth`). Each pack has its own controllers, actors, specs, and routes module.
 
+**ApiRequestLog Observability** - `ApiRequestLoggerMiddleware` (`app/middleware/`) records every `/api/*` request to the `api_request_logs` table (method, endpoint, headers, payload, response, duration, user). Admin dashboards under `/admin` expose: Daily Overview, Requests Dashboard, Non-2xx API logs, User Analytics, User Lookup, Request logs by payload, plus the raw `ApiRequestLog` Administrate CRUD.
+
 ### Directory Structure
 
 - `app/actors/` - ServiceActor business logic

--- a/backend/app/controllers/admin/api_error_logs_controller.rb
+++ b/backend/app/controllers/admin/api_error_logs_controller.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Admin
+  class ApiErrorLogsController < Admin::ApplicationController
+    UNKNOWN_APP_VERSION = "unknown"
+
+    def index
+      logs = filtered_logs_scope.includes(:user).order(started_at: :desc).to_a
+
+      @app_versions = available_app_versions
+      @grouped_logs = group_logs_by_response_code(logs)
+      @chart_data = build_chart_data(logs)
+      @chart_data_by_version = build_chart_data_by_version(logs)
+    end
+
+    private
+
+    helper_method :filters
+
+    def filters
+      @filters ||= {
+        email: params[:email].to_s.strip,
+        start_date: parse_date(params[:start_date]) || 30.days.ago.to_date,
+        end_date: parse_date(params[:end_date]) || Date.tomorrow,
+        app_version: params[:app_version].presence
+      }
+    end
+
+    def non_2xx_scope
+      ApiRequestLog.where.not("response_code BETWEEN 200 AND 299")
+    end
+
+    def filtered_logs_scope
+      scope = non_2xx_scope
+      scope = filter_by_email(scope)
+      scope = filter_by_date_range(scope)
+      filter_by_app_version(scope)
+    end
+
+    def filter_by_email(scope)
+      email = filters[:email].presence
+      return scope unless email
+
+      scope.joins(:user).where("users.email ILIKE ?", "%#{email}%")
+    end
+
+    def filter_by_date_range(scope)
+      from = filters[:start_date]
+      to = filters[:end_date]
+      scope = scope.where(started_at: from.beginning_of_day..) if from
+      scope = scope.where(started_at: ..to.end_of_day) if to
+      scope
+    end
+
+    def filter_by_app_version(scope)
+      version = filters[:app_version]
+      return scope if version.blank?
+      return scope.where("headers->>'App-Version' IS NULL") if version == UNKNOWN_APP_VERSION
+
+      scope.where("headers->>'App-Version' = ?", version)
+    end
+
+    def available_app_versions
+      non_2xx_scope
+        .distinct
+        .pluck(Arel.sql("headers->>'App-Version'"))
+        .map { |version| version.presence || UNKNOWN_APP_VERSION }
+        .uniq
+        .sort
+    end
+
+    def group_logs_by_response_code(logs)
+      logs.group_by(&:response_code).sort_by { |_code, group_logs| -group_logs.first.started_at.to_f }
+    end
+
+    def parse_date(value)
+      return nil if value.blank?
+
+      Date.parse(value)
+    rescue ArgumentError
+      nil
+    end
+
+    def chart_date_range
+      (filters[:start_date]..filters[:end_date])
+    end
+
+    def build_chart_data(logs)
+      by_code_and_date = logs.group_by(&:response_code).transform_values do |code_logs|
+        counts = code_logs.group_by { |log| log.created_at.to_date }.transform_values(&:size)
+        chart_date_range.each_with_object({}) { |date, h| h[date.to_s] = counts[date].to_i }
+      end
+
+      by_code_and_date.sort_by { |code, _| code }.to_h
+    end
+
+    def build_chart_data_by_version(logs)
+      logs.group_by(&:response_code).sort_by { |code, _| code }.to_h.transform_values do |code_logs|
+        versions_per_day_for(code_logs)
+      end
+    end
+
+    def versions_per_day_for(code_logs)
+      logs_by_date = code_logs.group_by { |log| log.created_at.to_date }
+      chart_date_range.each_with_object({}) do |date, versions_by_date|
+        versions_by_date[date.to_s] = count_versions(logs_by_date[date] || [])
+      end
+    end
+
+    def count_versions(day_logs)
+      day_logs.each_with_object(Hash.new(0)) { |log, counts| counts[app_version(log)] += 1 }
+    end
+
+    def app_version(log)
+      log.headers&.dig("App-Version") || UNKNOWN_APP_VERSION
+    end
+  end
+end

--- a/backend/app/controllers/admin/api_request_logs_controller.rb
+++ b/backend/app/controllers/admin/api_request_logs_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Admin
+  class ApiRequestLogsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/backend/app/controllers/admin/daily_overview_controller.rb
+++ b/backend/app/controllers/admin/daily_overview_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Admin
+  class DailyOverviewController < Admin::ApplicationController
+    DEFAULT_DAYS = 30
+    TRACKED_ENTITIES = {
+      "Users" => User,
+      "API Request Logs" => ApiRequestLog
+    }.freeze
+
+    def index
+      @days = parse_days(params[:days])
+      @labels = build_labels(@days)
+      @datasets = TRACKED_ENTITIES.map { |name, klass| build_dataset(name, klass) }
+    end
+
+    private
+
+    def parse_days(value)
+      return DEFAULT_DAYS if value.blank?
+
+      value.to_i.clamp(7, 180)
+    end
+
+    def start_date
+      Date.current - (@days - 1)
+    end
+
+    def build_labels(_days)
+      (start_date..Date.current).map { |d| d.strftime("%d/%m") }
+    end
+
+    def build_dataset(label, klass)
+      counts = klass
+        .where(created_at: start_date.beginning_of_day..Time.current)
+        .group(Arel.sql("DATE(created_at)"))
+        .count
+
+      counts_by_date = counts.transform_keys { |k| k.is_a?(String) ? Date.parse(k) : k }
+      data = (start_date..Date.current).map { |d| counts_by_date[d].to_i }
+      { label: label, slug: label.parameterize, data: data }
+    end
+  end
+end

--- a/backend/app/controllers/admin/request_logs_by_payload_controller.rb
+++ b/backend/app/controllers/admin/request_logs_by_payload_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Admin
+  class RequestLogsByPayloadController < Admin::ApplicationController
+    def index
+      @group_by = params[:group_by].presence_in(%w[payload response]) || "payload"
+      @selected_date = params[:date].presence
+      @grouped_logs = fetch_grouped_logs
+      @daily_totals = fetch_daily_totals
+    end
+
+    def details
+      @logs = fetch_detail_logs
+      @filter_description = build_filter_description
+    end
+
+    private
+
+    def fetch_grouped_logs
+      scoped_logs
+        .joins("LEFT JOIN users ON users.id = api_request_logs.user_id")
+        .select(*grouped_select_columns)
+        .group(grouped_by_sql)
+        .order(Arel.sql("DATE(api_request_logs.started_at) DESC, COUNT(*) DESC"))
+        .to_a
+    end
+
+    def group_value_column
+      @group_by == "response" ? "api_request_logs.response" : "api_request_logs.payload"
+    end
+
+    def grouped_select_columns
+      col = group_value_column
+      [
+        "#{col} AS group_value", "MD5(#{col}::text) AS group_digest",
+        "api_request_logs.response_code",
+        "DATE(api_request_logs.started_at) AS request_date",
+        "COALESCE(users.email, 'anonymous') AS user_email",
+        "api_request_logs.headers->>'App-Version' AS app_version",
+        "COUNT(*) AS request_count"
+      ]
+    end
+
+    def grouped_by_sql
+      "#{group_value_column}, api_request_logs.response_code, " \
+        "DATE(api_request_logs.started_at), COALESCE(users.email, 'anonymous'), " \
+        "api_request_logs.headers->>'App-Version'"
+    end
+
+    def fetch_daily_totals
+      scoped_logs.group("DATE(started_at)").order("DATE(started_at) DESC").count
+    end
+
+    def scoped_logs
+      scope = non_2xx_logs_scope
+      scope = scope.where("DATE(api_request_logs.started_at) = ?", @selected_date) if @selected_date.present?
+      scope
+    end
+
+    def non_2xx_logs_scope
+      ApiRequestLog
+        .where.not("response_code BETWEEN 200 AND 299")
+        .where(api_request_logs: { started_at: 10.days.ago.beginning_of_day.. })
+    end
+
+    def fetch_detail_logs
+      scope = non_2xx_logs_scope.eager_load(:user)
+      scope = scope.where("DATE(api_request_logs.started_at) = ?", params[:date]) if params[:date].present?
+      scope = scope.where(response_code: params[:response_code]) if params[:response_code].present?
+      scope = scope.where("COALESCE(users.email, 'anonymous') = ?", params[:user_email]) if params[:user_email].present?
+
+      if params[:group_by] == "response" && params[:group_digest].present?
+        scope = scope.where("MD5(api_request_logs.response::text) = ?", params[:group_digest])
+      elsif params[:group_digest].present?
+        scope = scope.where("MD5(api_request_logs.payload::text) = ?", params[:group_digest])
+      end
+
+      scope.order(started_at: :desc).limit(200)
+    end
+
+    def build_filter_description
+      parts = []
+      parts << "Date: #{params[:date]}" if params[:date].present?
+      parts << "Response code: #{params[:response_code]}" if params[:response_code].present?
+      parts << "User: #{params[:user_email]}" if params[:user_email].present?
+      parts << "Grouped by: #{params[:group_by] || 'payload'}" if params[:group_digest].present?
+      parts.join(" | ")
+    end
+  end
+end

--- a/backend/app/controllers/admin/requests_dashboard_controller.rb
+++ b/backend/app/controllers/admin/requests_dashboard_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Admin
+  class RequestsDashboardController < Admin::ApplicationController
+    def index
+      @users = User.order(:email)
+      @email_query = params[:email].to_s.strip
+      @selected_user = find_selected_user
+
+      return unless @selected_user
+
+      @success_requests = grouped_requests(@selected_user, success_only: true)
+      @error_requests = grouped_requests(@selected_user, errors_only: true)
+    end
+
+    private
+
+    def find_selected_user
+      return User.find(params[:user_id]) if params[:user_id].present?
+      return nil if @email_query.blank?
+
+      User.where("email ILIKE ?", "%#{@email_query}%").order(:email).first
+    end
+
+    def grouped_requests(user, success_only: false, errors_only: false)
+      scope = ApiRequestLog.where(user_id: user.id)
+      scope = scope.where("response_code BETWEEN 200 AND 299") if success_only
+      scope = scope.where.not("response_code BETWEEN 200 AND 299") if errors_only
+
+      scope
+        .select(*aggregation_columns)
+        .group("http_method, endpoint, response_code, DATE(started_at)")
+        .order("DATE(started_at) DESC, http_method, endpoint, response_code")
+    end
+
+    def aggregation_columns
+      [
+        "http_method", "endpoint", "response_code",
+        "DATE(started_at) AS request_date",
+        "COUNT(*) AS request_count",
+        "MIN(started_at) AS first_request_at",
+        "MAX(started_at) AS last_request_at"
+      ]
+    end
+  end
+end

--- a/backend/app/controllers/admin/user_analytics_controller.rb
+++ b/backend/app/controllers/admin/user_analytics_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Admin
+  class UserAnalyticsController < Admin::ApplicationController
+    def index
+      @start_date = parse_date(params[:start_date], 30.days.ago.to_date)
+      @end_date = parse_date(params[:end_date], Date.current)
+      @total_users = User.count
+      @chart_data = build_chart_data
+    end
+
+    private
+
+    def date_range
+      @start_date.beginning_of_day..@end_date.end_of_day
+    end
+
+    def build_chart_data
+      {
+        date_labels: (@start_date..@end_date).to_a,
+        users_per_day: users_per_day
+      }
+    end
+
+    def users_per_day
+      User.where(created_at: date_range)
+        .group("DATE(created_at)")
+        .count
+    end
+
+    def parse_date(value, default)
+      return default if value.blank?
+
+      Date.parse(value)
+    rescue Date::Error
+      default
+    end
+  end
+end

--- a/backend/app/controllers/admin/user_lookup_controller.rb
+++ b/backend/app/controllers/admin/user_lookup_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Admin
+  class UserLookupController < Admin::ApplicationController
+    def index
+      @email_query = params[:email].to_s.strip
+      @user = User.find_by("email ILIKE ?", @email_query) if @email_query.present?
+
+      if @user
+        load_user_data
+        load_summary_stats
+      else
+        load_latest_active_users
+      end
+    end
+
+    private
+
+    def load_latest_active_users
+      ids_with_ts = ApiRequestLog.where.not(user_id: nil)
+        .group(:user_id)
+        .order(Arel.sql("MAX(started_at) DESC"))
+        .limit(20)
+        .pluck(:user_id, Arel.sql("MAX(started_at) AS last_activity"))
+      users_by_id = User.where(id: ids_with_ts.map(&:first)).index_by(&:id)
+      @latest_active_users = ids_with_ts.filter_map do |id, ts|
+        user = users_by_id[id]
+        [user, ts] if user
+      end
+    end
+
+    def load_user_data
+      @api_request_logs = @user.api_request_logs.order(started_at: :desc).limit(200)
+    end
+
+    def load_summary_stats
+      @last_api_activity = @user.api_request_logs.maximum(:started_at)
+      @inactive_days = @last_api_activity ? (Date.current - @last_api_activity.to_date).to_i : nil
+    end
+  end
+end

--- a/backend/app/dashboards/api_request_log_dashboard.rb
+++ b/backend/app/dashboards/api_request_log_dashboard.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class ApiRequestLogDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::String,
+    deleted_at: Field::DateTime,
+    duration_ms: Field::Number,
+    ended_at: Field::DateTime,
+    endpoint: Field::String,
+    headers: Field::String.with_options(searchable: false),
+    http_method: Field::String,
+    payload: Field::String.with_options(searchable: false),
+    response: Field::String.with_options(searchable: false),
+    response_code: Field::Number,
+    started_at: Field::DateTime,
+    summary: Field::Text,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    user
+    endpoint
+    http_method
+    payload
+    response
+    response_code
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    user
+    endpoint
+    headers
+    http_method
+    payload
+    response
+    response_code
+    started_at
+    deleted_at
+    duration_ms
+    ended_at
+    created_at
+    updated_at
+    summary
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    deleted_at
+    duration_ms
+    ended_at
+    endpoint
+    headers
+    http_method
+    payload
+    response
+    response_code
+    started_at
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how api request logs are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(api_request_log)
+  #   "ApiRequestLog ##{api_request_log.id}"
+  # end
+end

--- a/backend/app/middleware/api_request_logger_middleware.rb
+++ b/backend/app/middleware/api_request_logger_middleware.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class ApiRequestLoggerMiddleware
+  AUTHORIZATION_HEADER = "HTTP_AUTHORIZATION"
+  BEARER_PREFIX = "Bearer "
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+    return @app.call(env) unless api_request?(request)
+
+    started_at, monotonic_started_at = start_times
+    payload = parse_body(request)
+    status, headers, response = @app.call(env)
+    response_body = collect_response_body(response)
+    ended_at = Time.current
+
+    log_request(
+      {
+        request:,
+        env:,
+        payload:,
+        status:,
+        response_body:,
+        started_at:,
+        ended_at:,
+        monotonic_started_at:
+      }
+    )
+
+    [status, headers, [response_body]]
+  end
+
+  private
+
+  def start_times
+    [Time.current, Process.clock_gettime(Process::CLOCK_MONOTONIC)]
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def log_request(data)
+    ApiRequestLog.create!(
+      user_id: resolve_user_id(data[:env]),
+      http_method: data[:request].request_method,
+      endpoint: data[:request].fullpath,
+      headers: extract_headers(data[:request]),
+      payload: data[:payload],
+      response_code: data[:status],
+      response: build_response_payload(data[:status], data[:response_body]),
+      started_at: data[:started_at],
+      ended_at: data[:ended_at],
+      duration_ms: elapsed_milliseconds(data[:monotonic_started_at])
+    )
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def api_request?(request)
+    request.path.start_with?("/api/")
+  end
+
+  def parse_body(request)
+    raw_body = request.raw_post
+    return {} if raw_body.blank?
+
+    return JSON.parse(raw_body) if json_content_type?(request.content_type)
+
+    Rack::Utils.parse_nested_query(raw_body)
+  rescue JSON::ParserError
+    { raw: raw_body }
+  end
+
+  def json_content_type?(content_type)
+    content_type.to_s.include?("application/json")
+  end
+
+  def collect_response_body(response)
+    body = +""
+    response.each { |chunk| body << chunk.to_s }
+    response.close if response.respond_to?(:close)
+    body
+  end
+
+  def build_response_payload(status, raw_response_body)
+    parsed_body = (JSON.parse(raw_response_body) if raw_response_body.present?)
+
+    {
+      status: status,
+      body: parsed_body
+    }
+  rescue JSON::ParserError
+    {
+      status: status,
+      body: raw_response_body
+    }
+  end
+
+  def elapsed_milliseconds(monotonic_started_at)
+    elapsed_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC) - monotonic_started_at
+    (elapsed_seconds * 1000.0).round
+  end
+
+  def extract_headers(request)
+    request.headers.env
+      .select { |key, _value| key.start_with?("HTTP_") || key == "CONTENT_TYPE" || key == "CONTENT_LENGTH" }
+      .transform_keys do |key|
+        key.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
+      end
+  end
+
+  def resolve_user_id(env)
+    authorization = env[AUTHORIZATION_HEADER].to_s
+    return if authorization.blank?
+    return unless authorization.start_with?(BEARER_PREFIX)
+
+    access_token = authorization.delete_prefix(BEARER_PREFIX)
+    return if access_token.blank?
+
+    Devise::Api::Token.find_by(access_token: access_token)&.resource_owner_id
+  end
+end

--- a/backend/app/models/api_request_log.rb
+++ b/backend/app/models/api_request_log.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ApiRequestLog < ApplicationRecord
+  belongs_to :user, optional: true
+
+  validates :http_method, :endpoint, :response_code, :started_at, :ended_at, :duration_ms, presence: true
+
+  def summary
+    <<~TEXT
+      On a request with http method #{http_method} and endpoint #{endpoint}, the response code is #{response_code} and the response body is:
+
+      #{response}
+
+      The request payload is:
+
+      #{payload}
+
+      The request headers are:
+
+      #{headers}
+    TEXT
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -32,5 +32,7 @@ class User < ApplicationRecord
     :recoverable, :rememberable, :validatable, :api,
     :omniauthable, omniauth_providers: %i[github strava]
 
+  has_many :api_request_logs, dependent: :nullify
+
   validates :email, uniqueness: { case_sensitive: false }
 end

--- a/backend/app/views/admin/api_error_logs/index.html.erb
+++ b/backend/app/views/admin/api_error_logs/index.html.erb
@@ -1,0 +1,191 @@
+<% content_for(:title) { "Non-2xx API request logs" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">Non-2xx API request logs</h1>
+</header>
+
+<section class="main-content__body">
+  <form method="get" action="<%= admin_api_error_logs_path %>"
+        style="margin-bottom: 1rem; display: flex; flex-wrap: wrap; align-items: end; gap: 1rem;">
+    <div style="display: flex; flex-direction: column;">
+      <label for="email" style="font-weight: bold; font-size: 0.875rem;">User email</label>
+      <input type="text" name="email" id="email" value="<%= filters[:email] %>"
+             placeholder="user@example.com"
+             style="padding: 0.5rem; min-width: 260px;">
+    </div>
+    <div style="display: flex; flex-direction: column;">
+      <label for="start_date" style="font-weight: bold; font-size: 0.875rem;">From</label>
+      <input type="date" name="start_date" id="start_date"
+             value="<%= filters[:start_date]&.iso8601 %>" style="padding: 0.5rem;">
+    </div>
+    <div style="display: flex; flex-direction: column;">
+      <label for="end_date" style="font-weight: bold; font-size: 0.875rem;">To</label>
+      <input type="date" name="end_date" id="end_date"
+             value="<%= filters[:end_date]&.iso8601 %>" style="padding: 0.5rem;">
+    </div>
+    <div style="display: flex; flex-direction: column;">
+      <label for="app_version" style="font-weight: bold; font-size: 0.875rem;">App version</label>
+      <select name="app_version" id="app_version"
+              style="padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px;">
+        <option value="">All</option>
+        <% @app_versions.each do |version| %>
+          <option value="<%= version %>" <%= "selected" if filters[:app_version] == version %>><%= version %></option>
+        <% end %>
+      </select>
+    </div>
+    <button type="submit"
+            style="padding: 0.5rem 1rem; background: #4f46e5; color: white; border: none; border-radius: 4px; cursor: pointer;">
+      Apply
+    </button>
+    <% if filters[:email].present? || filters[:start_date] || filters[:end_date] || filters[:app_version] %>
+      <a href="<%= admin_api_error_logs_path %>"
+         style="padding: 0.5rem 1rem; color: #4f46e5; text-decoration: none;">Clear</a>
+    <% end %>
+  </form>
+
+  <% if filters[:app_version] %>
+    <div style="margin-bottom: 1.5rem;">
+      <span style="display: inline-flex; align-items: center; gap: 0.5rem; background: #e0f2fe; color: #0369a1; padding: 0.35rem 0.75rem; border-radius: 6px; font-size: 0.875rem; font-weight: 500;">
+        Filtered: <%= filters[:app_version] %>
+        <a href="<%= admin_api_error_logs_path %>" style="color: #0369a1; text-decoration: none; font-weight: bold;" title="Clear filter">&times;</a>
+      </span>
+    </div>
+  <% end %>
+
+  <% unless @chart_data.empty? %>
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; margin-bottom: 2rem;">
+      <% @chart_data.each do |response_code, _dates_counts| %>
+        <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem;">
+          <h2 style="margin-top: 0; font-size: 1.125rem; color: #1e293b;">HTTP <%= response_code %> — Errors per Day</h2>
+          <canvas id="chart-<%= response_code %>"></canvas>
+        </div>
+      <% end %>
+    </div>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; margin-bottom: 2rem;">
+      <% @chart_data_by_version.each do |response_code, _| %>
+        <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem;">
+          <h2 style="margin-top: 0; font-size: 1.125rem; color: #1e293b;">HTTP <%= response_code %> — Errors per Day by App-Version</h2>
+          <canvas id="version-chart-<%= response_code %>"></canvas>
+        </div>
+      <% end %>
+    </div>
+
+    <script>
+      function loadChartJs(callback) {
+        if (typeof Chart !== "undefined") { callback(); return; }
+        var script = document.createElement("script");
+        script.src = "https://cdn.jsdelivr.net/npm/chart.js";
+        script.onload = callback;
+        document.head.appendChild(script);
+      }
+
+      function renderErrorCharts() {
+        var chartData = <%= raw @chart_data.to_json %>;
+        var colors = { 400: "#f59e0b", 401: "#ef4444", 403: "#dc2626", 404: "#8b5cf6", 422: "#f97316", 500: "#b91c1c", 502: "#991b1b", 503: "#7c2d12" };
+
+        Object.keys(chartData).forEach(function(code) {
+          var dateCounts = chartData[code];
+          var dates = Object.keys(dateCounts).sort();
+          var counts = dates.map(function(d) { return dateCounts[d]; });
+          var color = colors[code] || "#6366f1";
+
+          new Chart(document.getElementById("chart-" + code), {
+            type: "bar",
+            data: {
+              labels: dates,
+              datasets: [{ label: "HTTP " + code, data: counts, backgroundColor: color, borderRadius: 4 }]
+            },
+            options: {
+              responsive: true,
+              plugins: { legend: { display: false } },
+              scales: {
+                x: { title: { display: true, text: "Date" } },
+                y: { title: { display: true, text: "Count" }, beginAtZero: true, ticks: { stepSize: 1 } }
+              }
+            }
+          });
+        });
+
+        var versionChartData = <%= raw @chart_data_by_version.to_json %>;
+        var versionPalette = [
+          "#6366f1", "#22c55e", "#f59e0b", "#ef4444", "#8b5cf6",
+          "#ec4899", "#14b8a6", "#f97316", "#64748b", "#06b6d4"
+        ];
+
+        Object.keys(versionChartData).forEach(function(code) {
+          var dateVersions = versionChartData[code];
+          var dates = Object.keys(dateVersions).sort();
+          var versionsSet = {};
+          dates.forEach(function(d) {
+            Object.keys(dateVersions[d]).forEach(function(v) { versionsSet[v] = true; });
+          });
+          var versions = Object.keys(versionsSet).sort();
+
+          var datasets = versions.map(function(version, i) {
+            return {
+              label: version,
+              data: dates.map(function(d) { return dateVersions[d][version] || 0; }),
+              backgroundColor: versionPalette[i % versionPalette.length],
+              borderRadius: 4
+            };
+          });
+
+          new Chart(document.getElementById("version-chart-" + code), {
+            type: "bar",
+            data: { labels: dates, datasets: datasets },
+            options: {
+              responsive: true,
+              plugins: { legend: { display: true, position: "top" } },
+              scales: {
+                x: { stacked: true, title: { display: true, text: "Date" } },
+                y: { stacked: true, title: { display: true, text: "Count" }, beginAtZero: true, ticks: { stepSize: 1 } }
+              }
+            }
+          });
+        });
+      }
+
+      loadChartJs(renderErrorCharts);
+    </script>
+  <% end %>
+
+  <% if @grouped_logs.empty? %>
+    <p>No non-2xx API request logs found<%= " for app version #{filters[:app_version]}" if filters[:app_version] %>.</p>
+  <% else %>
+    <% @grouped_logs.each do |response_code, logs| %>
+      <details open style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem;">
+        <summary style="cursor: pointer; font-size: 1.125rem; font-weight: bold; color: #1e293b;">
+          HTTP <%= response_code %>
+          <span style="font-weight: normal; color: #64748b; font-size: 0.875rem;">
+            (<%= logs.size %> <%= logs.size == 1 ? "request" : "requests" %>)
+          </span>
+        </summary>
+        <table class="collection-data" style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+          <thead>
+            <tr>
+              <th style="text-align: left; padding: 0.5rem;">Started at</th>
+              <th style="text-align: left; padding: 0.5rem;">User</th>
+              <th style="text-align: left; padding: 0.5rem;">HTTP method</th>
+              <th style="text-align: left; padding: 0.5rem;">Endpoint</th>
+              <th style="text-align: left; padding: 0.5rem;">Response</th>
+              <th style="text-align: left; padding: 0.5rem;">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% logs.each do |log| %>
+              <tr>
+                <td style="padding: 0.5rem;"><%= l(log.started_at, format: :long) %></td>
+                <td style="padding: 0.5rem;"><%= log.user&.email || "—" %></td>
+                <td style="padding: 0.5rem;"><%= log.http_method %></td>
+                <td style="padding: 0.5rem;"><%= log.endpoint %></td>
+                <td style="padding: 0.5rem; max-width: 28rem; font-family: monospace; font-size: 0.75rem; white-space: pre-wrap; word-break: break-word; vertical-align: top;"><%= JSON.pretty_generate(log.response) %></td>
+                <td style="padding: 0.5rem;"><%= link_to "View", admin_api_request_log_path(log), class: "navigation__link" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </details>
+    <% end %>
+  <% end %>
+</section>

--- a/backend/app/views/admin/application/_navigation.html.erb
+++ b/backend/app/views/admin/application/_navigation.html.erb
@@ -1,0 +1,42 @@
+<nav class="navigation" role="navigation">
+  <a href="/" class="navigation__logo">
+    <%= application_title %>
+  </a>
+
+  <div>
+    <ul class="navigation__links">
+      <% Administrate::Namespace.new(:admin).resources_with_index_route.reject { |r| %w[daily_overview requests_dashboard api_error_logs user_analytics user_lookup request_logs_by_payload].include?(r.to_s) }.each do |resource| %>
+        <li class="navigation__link">
+          <%= link_to(
+            display_resource_name(resource),
+            resource_index_route(resource),
+            class: "navigation__link"
+          ) %>
+        </li>
+      <% end %>
+
+      <li style="list-style: none; margin: 0.5rem 0;">
+        <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 0;">
+      </li>
+
+      <li class="navigation__link">
+        <%= link_to "Daily Overview", admin_daily_overview_index_path, class: "navigation__link" %>
+      </li>
+      <li class="navigation__link">
+        <%= link_to "Requests Dashboard", admin_requests_dashboard_index_path, class: "navigation__link" %>
+      </li>
+      <li class="navigation__link">
+        <%= link_to "Non-2xx API logs", admin_api_error_logs_path, class: "navigation__link" %>
+      </li>
+      <li class="navigation__link">
+        <%= link_to "User Analytics", admin_user_analytics_path, class: "navigation__link" %>
+      </li>
+      <li class="navigation__link">
+        <%= link_to "User Lookup", admin_user_lookup_index_path, class: "navigation__link" %>
+      </li>
+      <li class="navigation__link">
+        <%= link_to "Request logs by payload", admin_request_logs_by_payload_index_path, class: "navigation__link" %>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/backend/app/views/admin/daily_overview/index.html.erb
+++ b/backend/app/views/admin/daily_overview/index.html.erb
@@ -1,0 +1,104 @@
+<% content_for(:title) { "Daily Overview" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">Daily Overview</h1>
+</header>
+
+<section class="main-content__body">
+  <form method="get" action="<%= admin_daily_overview_index_path %>" style="margin-bottom: 1.5rem; display: flex; align-items: center; gap: 1rem;">
+    <label for="days" style="font-weight: bold;">Range:</label>
+    <select name="days" id="days" style="padding: 0.5rem;" onchange="this.form.submit()">
+      <% [7, 15, 30, 60, 90, 180].each do |n| %>
+        <option value="<%= n %>" <%= "selected" if n == @days %>>Last <%= n %> days</option>
+      <% end %>
+    </select>
+  </form>
+
+  <% palette = %w[#4f46e5 #10b981 #f472b6 #eab308 #3b82f6 #ef4444] %>
+  <% @datasets.each_with_index do |dataset, idx| %>
+    <% color = palette[idx % palette.size] %>
+    <% total = dataset[:data].sum %>
+    <div style="display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr); gap: 1.5rem; margin-bottom: 1.5rem; align-items: stretch;">
+      <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.25rem;">
+        <h2 style="margin-top: 0; font-size: 1rem; color: #1e293b;"><%= dataset[:label] %> — last <%= @days %> days</h2>
+        <canvas id="chart-<%= dataset[:slug] %>" style="max-height: 280px;"></canvas>
+      </div>
+      <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.25rem; overflow-y: auto; max-height: 360px;">
+        <h3 style="margin-top: 0; font-size: 0.95rem; color: #1e293b;">Daily counts</h3>
+        <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+          <thead>
+            <tr style="border-bottom: 2px solid #e2e8f0; position: sticky; top: 0; background: #f8fafc;">
+              <th style="text-align: left; padding: 0.4rem; color: #64748b;">Date</th>
+              <th style="text-align: right; padding: 0.4rem; color: #64748b;">Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @labels.zip(dataset[:data]).each do |label, count| %>
+              <tr style="border-bottom: 1px solid #e2e8f0;">
+                <td style="padding: 0.35rem 0.4rem;"><%= label %></td>
+                <td style="padding: 0.35rem 0.4rem; text-align: right;"><%= count %></td>
+              </tr>
+            <% end %>
+            <tr style="border-top: 2px solid #e2e8f0;">
+              <td style="padding: 0.4rem; font-weight: bold;">Total</td>
+              <td style="padding: 0.4rem; text-align: right; font-weight: bold;"><%= total %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+</section>
+
+<script>
+  function loadChartJs(callback) {
+    if (typeof Chart !== "undefined") { callback(); return; }
+    var script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/chart.js";
+    script.onload = callback;
+    document.head.appendChild(script);
+  }
+
+  function renderDailyOverviewCharts() {
+    var labels = <%= raw @labels.to_json %>;
+    var datasets = <%= raw @datasets.to_json %>;
+    var palette = [
+      "rgba(79, 70, 229, 0.75)",
+      "rgba(16, 185, 129, 0.75)",
+      "rgba(244, 114, 182, 0.75)",
+      "rgba(234, 179, 8, 0.75)",
+      "rgba(59, 130, 246, 0.75)",
+      "rgba(239, 68, 68, 0.75)"
+    ];
+
+    datasets.forEach(function(ds, idx) {
+      var canvas = document.getElementById("chart-" + ds.slug);
+      if (!canvas) return;
+      var color = palette[idx % palette.length];
+      new Chart(canvas, {
+        type: "bar",
+        data: {
+          labels: labels,
+          datasets: [{
+            label: ds.label,
+            data: ds.data,
+            backgroundColor: color,
+            borderColor: color.replace("0.75", "1"),
+            borderWidth: 1
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: true,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ticks: { maxRotation: 45, minRotation: 0, autoSkip: true, maxTicksLimit: 20 } },
+            y: { beginAtZero: true, ticks: { stepSize: 1 } }
+          }
+        }
+      });
+    });
+  }
+
+  loadChartJs(renderDailyOverviewCharts);
+</script>

--- a/backend/app/views/admin/request_logs_by_payload/details.html.erb
+++ b/backend/app/views/admin/request_logs_by_payload/details.html.erb
@@ -1,0 +1,50 @@
+<% content_for(:title) { "Request log details" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">Request log details</h1>
+  <p style="color: #64748b; margin-top: 0.25rem;"><%= @filter_description %></p>
+  <a href="<%= admin_request_logs_by_payload_index_path(group_by: params[:group_by], date: params[:date]) %>" style="color: #2563eb; text-decoration: none; font-size: 0.875rem;">&larr; Back to grouped view</a>
+</header>
+
+<section class="main-content__body">
+  <% if @logs.empty? %>
+    <p>No matching logs found.</p>
+  <% else %>
+    <p style="color: #64748b; font-size: 0.875rem; margin-bottom: 1rem;">Showing <%= @logs.size %> log<%= @logs.size == 1 ? "" : "s" %> (max 200)</p>
+
+    <table class="collection-data" style="width: 100%; border-collapse: collapse;">
+      <thead>
+        <tr>
+          <th style="text-align: left; padding: 0.5rem;">Started at</th>
+          <th style="text-align: left; padding: 0.5rem;">User</th>
+          <th style="text-align: left; padding: 0.5rem;">Method</th>
+          <th style="text-align: left; padding: 0.5rem;">Endpoint</th>
+          <th style="text-align: center; padding: 0.5rem;">Response Code</th>
+          <th style="text-align: left; padding: 0.5rem;">App-Version</th>
+          <th style="text-align: left; padding: 0.5rem;">Payload</th>
+          <th style="text-align: left; padding: 0.5rem;">Response</th>
+          <th style="text-align: left; padding: 0.5rem;">Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @logs.each do |log| %>
+          <tr>
+            <td style="padding: 0.5rem; white-space: nowrap;"><%= log.started_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+            <td style="padding: 0.5rem;"><%= log.user&.email || "anonymous" %></td>
+            <td style="padding: 0.5rem;"><%= log.http_method %></td>
+            <td style="padding: 0.5rem;"><%= log.endpoint %></td>
+            <td style="padding: 0.5rem; text-align: center;">
+              <span style="display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.8rem; font-weight: 600; background: <%= log.response_code >= 500 ? '#fef2f2; color: #991b1b' : '#fef9c3; color: #854d0e' %>;">
+                <%= log.response_code %>
+              </span>
+            </td>
+            <td style="padding: 0.5rem;"><%= log.headers&.dig("App-Version") || "unknown" %></td>
+            <td style="padding: 0.5rem; max-width: 20rem; font-family: monospace; font-size: 0.7rem; white-space: pre-wrap; word-break: break-word; vertical-align: top;"><%= JSON.pretty_generate(log.payload) rescue log.payload %></td>
+            <td style="padding: 0.5rem; max-width: 20rem; font-family: monospace; font-size: 0.7rem; white-space: pre-wrap; word-break: break-word; vertical-align: top;"><%= JSON.pretty_generate(log.response) rescue log.response %></td>
+            <td style="padding: 0.5rem;"><%= link_to "View", admin_api_request_log_path(log), class: "navigation__link" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/backend/app/views/admin/request_logs_by_payload/index.html.erb
+++ b/backend/app/views/admin/request_logs_by_payload/index.html.erb
@@ -1,0 +1,101 @@
+<% content_for(:title) { "Request logs by payload" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">Request logs by payload</h1>
+  <p style="color: #64748b; margin-top: 0.25rem;">Non-2xx API request logs from the last 10 days, grouped by <%= @group_by %>, response code, day, and user email.</p>
+</header>
+
+<section class="main-content__body">
+  <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
+    <form method="get" action="<%= admin_request_logs_by_payload_index_path %>" style="display: flex; align-items: center; gap: 0.5rem;">
+      <label for="group_by" style="font-weight: 600; color: #1e293b;">Group by:</label>
+      <select name="group_by" id="group_by" onchange="this.form.submit()" style="padding: 0.4rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 0.875rem;">
+        <option value="payload" <%= "selected" if @group_by == "payload" %>>Payload</option>
+        <option value="response" <%= "selected" if @group_by == "response" %>>Response</option>
+      </select>
+      <% if @selected_date.present? %>
+        <input type="hidden" name="date" value="<%= @selected_date %>">
+      <% end %>
+    </form>
+
+    <% if @selected_date.present? %>
+      <span style="display: inline-flex; align-items: center; gap: 0.5rem; background: #e0f2fe; color: #0369a1; padding: 0.35rem 0.75rem; border-radius: 6px; font-size: 0.875rem; font-weight: 500;">
+        Filtered: <%= @selected_date %>
+        <a href="<%= admin_request_logs_by_payload_index_path(group_by: @group_by) %>" style="color: #0369a1; text-decoration: none; font-weight: bold;" title="Clear filter">&times;</a>
+      </span>
+    <% end %>
+  </div>
+
+  <% if @grouped_logs.empty? %>
+    <p>No non-2xx API request logs found<%= " for #{@selected_date}" if @selected_date.present? %>.</p>
+  <% else %>
+    <details open style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem;">
+      <summary style="cursor: pointer; font-size: 1.125rem; font-weight: bold; color: #1e293b;">
+        Total non-2xx requests per day
+      </summary>
+      <table class="collection-data" style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th style="text-align: left; padding: 0.5rem;">Date</th>
+            <th style="text-align: right; padding: 0.5rem;">Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @daily_totals.each do |date, count| %>
+            <tr>
+              <td style="padding: 0.5rem;">
+                <% if @selected_date == date.to_s %>
+                  <strong><%= date %></strong>
+                <% else %>
+                  <a href="<%= admin_request_logs_by_payload_index_path(group_by: @group_by, date: date) %>" style="color: #2563eb; text-decoration: none;"><%= date %></a>
+                <% end %>
+              </td>
+              <td style="padding: 0.5rem; text-align: right; font-weight: bold;"><%= count %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </details>
+
+    <details open style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem;">
+      <summary style="cursor: pointer; font-size: 1.125rem; font-weight: bold; color: #1e293b;">
+        Grouped by <%= @group_by %>, response code, day, and user
+        <span style="font-weight: normal; color: #64748b; font-size: 0.875rem;">
+          (<%= @grouped_logs.size %> <%= @grouped_logs.size == 1 ? "group" : "groups" %>)
+        </span>
+      </summary>
+      <table class="collection-data" style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th style="text-align: left; padding: 0.5rem;">Date</th>
+            <th style="text-align: left; padding: 0.5rem;">User email</th>
+            <th style="text-align: left; padding: 0.5rem;">App version</th>
+            <th style="text-align: center; padding: 0.5rem;">Response Code</th>
+            <th style="text-align: right; padding: 0.5rem;">Count</th>
+            <th style="text-align: left; padding: 0.5rem;"><%= @group_by.capitalize %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @grouped_logs.each do |log| %>
+            <tr>
+              <td style="padding: 0.5rem;">
+                <a href="<%= admin_request_logs_by_payload_index_path(group_by: @group_by, date: log.request_date) %>" style="color: #2563eb; text-decoration: none;"><%= log.request_date %></a>
+              </td>
+              <td style="padding: 0.5rem;"><%= log.user_email %></td>
+              <td style="padding: 0.5rem; font-family: monospace; font-size: 0.8rem;"><%= log.app_version.presence || "—" %></td>
+              <td style="padding: 0.5rem; text-align: center;">
+                <span style="display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.8rem; font-weight: 600; background: <%= log.response_code.to_i >= 500 ? '#fef2f2; color: #991b1b' : '#fef9c3; color: #854d0e' %>;">
+                  <%= log.response_code %>
+                </span>
+              </td>
+              <td style="padding: 0.5rem; text-align: right; font-weight: bold;">
+                <a href="<%= details_admin_request_logs_by_payload_index_path(date: log.request_date, user_email: log.user_email, response_code: log.response_code, group_by: @group_by, group_digest: log.group_digest) %>" target="_blank" style="color: #2563eb; text-decoration: none;" title="View individual logs"><%= log.request_count %></a>
+              </td>
+              <td style="padding: 0.5rem; max-width: 40rem; font-family: monospace; font-size: 0.75rem; white-space: pre-wrap; word-break: break-word; vertical-align: top;"><%= JSON.pretty_generate(log.group_value) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </details>
+  <% end %>
+</section>

--- a/backend/app/views/admin/requests_dashboard/_request_table.html.erb
+++ b/backend/app/views/admin/requests_dashboard/_request_table.html.erb
@@ -1,0 +1,26 @@
+<table class="collection-data" style="width: 100%; border-collapse: collapse;">
+  <thead>
+    <tr>
+      <th style="text-align: left; padding: 0.5rem;">Date</th>
+      <th style="text-align: left; padding: 0.5rem;">HTTP Method</th>
+      <th style="text-align: left; padding: 0.5rem;">Endpoint</th>
+      <th style="text-align: left; padding: 0.5rem;">Response Code</th>
+      <th style="text-align: right; padding: 0.5rem;">Count</th>
+      <th style="text-align: left; padding: 0.5rem;">First Request</th>
+      <th style="text-align: left; padding: 0.5rem;">Last Request</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% requests.each do |row| %>
+      <tr>
+        <td style="padding: 0.5rem;"><%= row.request_date %></td>
+        <td style="padding: 0.5rem;"><%= row.http_method %></td>
+        <td style="padding: 0.5rem;"><%= row.endpoint %></td>
+        <td style="padding: 0.5rem;"><%= row.response_code %></td>
+        <td style="padding: 0.5rem; text-align: right;"><%= row.request_count %></td>
+        <td style="padding: 0.5rem;"><%= row.first_request_at&.strftime("%H:%M:%S") %></td>
+        <td style="padding: 0.5rem;"><%= row.last_request_at&.strftime("%H:%M:%S") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/admin/requests_dashboard/index.html.erb
+++ b/backend/app/views/admin/requests_dashboard/index.html.erb
@@ -1,0 +1,52 @@
+<% content_for(:title) { "Requests Dashboard" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">Requests Dashboard by User</h1>
+</header>
+
+<section class="main-content__body">
+  <form method="get" action="<%= admin_requests_dashboard_index_path %>"
+        style="margin-bottom: 2rem; display: flex; flex-wrap: wrap; align-items: center; gap: 1rem;">
+    <div>
+      <label for="email" style="font-weight: bold; margin-right: 0.5rem;">Search by email:</label>
+      <input type="text" name="email" id="email" value="<%= @email_query %>"
+             placeholder="user@example.com"
+             style="padding: 0.5rem; min-width: 260px;">
+      <button type="submit"
+              style="padding: 0.5rem 1rem; background: #4f46e5; color: white; border: none; border-radius: 4px; cursor: pointer;">
+        Search
+      </button>
+    </div>
+    <div>
+      <label for="user_id" style="font-weight: bold; margin-right: 0.5rem;">or pick user:</label>
+      <select name="user_id" id="user_id" onchange="this.form.submit()" style="padding: 0.5rem; min-width: 300px;">
+        <option value="">-- Select a user --</option>
+        <% @users.each do |user| %>
+          <option value="<%= user.id %>" <%= "selected" if @selected_user&.id == user.id && params[:user_id].present? %>>
+            <%= user.email %>
+          </option>
+        <% end %>
+      </select>
+    </div>
+  </form>
+
+  <% if @email_query.present? && @selected_user.nil? %>
+    <p style="color: #b91c1c;">No user matched "<%= @email_query %>".</p>
+  <% end %>
+
+  <% if @selected_user %>
+    <h2 style="margin-top: 2rem;">2xx Requests for <%= @selected_user.email %></h2>
+    <% if @success_requests.any? %>
+      <%= render partial: "request_table", locals: { requests: @success_requests } %>
+    <% else %>
+      <p>No 2xx requests found.</p>
+    <% end %>
+
+    <h2 style="margin-top: 2rem;">Non-2xx Requests for <%= @selected_user.email %></h2>
+    <% if @error_requests.any? %>
+      <%= render partial: "request_table", locals: { requests: @error_requests } %>
+    <% else %>
+      <p>No non-2xx requests found.</p>
+    <% end %>
+  <% end %>
+</section>

--- a/backend/app/views/admin/user_analytics/index.html.erb
+++ b/backend/app/views/admin/user_analytics/index.html.erb
@@ -1,0 +1,67 @@
+<% content_for(:title) { "User Analytics" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">User Analytics</h1>
+</header>
+
+<section class="main-content__body">
+  <form method="get" action="<%= admin_user_analytics_path %>" style="margin-bottom: 2rem; display: flex; align-items: center; gap: 1rem;">
+    <label for="start_date" style="font-weight: bold;">From:</label>
+    <input type="date" name="start_date" id="start_date" value="<%= @start_date %>" style="padding: 0.5rem;">
+    <label for="end_date" style="font-weight: bold;">To:</label>
+    <input type="date" name="end_date" id="end_date" value="<%= @end_date %>" style="padding: 0.5rem;">
+    <button type="submit" style="padding: 0.5rem 1rem; background: #4f46e5; color: white; border: none; border-radius: 4px; cursor: pointer;">Filter</button>
+  </form>
+
+  <div style="display: flex; gap: 2rem; margin-bottom: 2rem; flex-wrap: wrap;">
+    <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem 2rem; min-width: 200px;">
+      <div style="font-size: 0.875rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.05em;">Total Users</div>
+      <div style="font-size: 2.5rem; font-weight: bold; color: #1e293b;" id="total-users"><%= @total_users %></div>
+    </div>
+  </div>
+
+  <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 2rem;">
+    <h2 style="margin-top: 0; font-size: 1.125rem; color: #1e293b;">Growth per Day</h2>
+    <canvas id="growthChart"></canvas>
+  </div>
+</section>
+
+<script>
+  function loadChartJs(callback) {
+    if (typeof Chart !== "undefined") { callback(); return; }
+    var script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/chart.js";
+    script.onload = callback;
+    document.head.appendChild(script);
+  }
+
+  function renderCharts() {
+    var growthCanvas = document.getElementById("growthChart");
+    if (!growthCanvas) return;
+
+    var labels = <%= raw @chart_data[:date_labels].map(&:to_s).to_json %>;
+    var growthData = <%= raw @chart_data[:date_labels].map { |d| @chart_data[:users_per_day][d] || 0 }.to_json %>;
+
+    new Chart(growthCanvas, {
+      type: "bar",
+      data: {
+        labels: labels,
+        datasets: [{
+          label: "New Users",
+          data: growthData,
+          backgroundColor: "rgba(79, 70, 229, 0.7)",
+          borderColor: "rgba(79, 70, 229, 1)",
+          borderWidth: 1
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          y: { beginAtZero: true, ticks: { stepSize: 1 } }
+        }
+      }
+    });
+  }
+
+  loadChartJs(renderCharts);
+</script>

--- a/backend/app/views/admin/user_lookup/index.html.erb
+++ b/backend/app/views/admin/user_lookup/index.html.erb
@@ -1,0 +1,122 @@
+<% content_for(:title) { "User Lookup" } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">User Lookup</h1>
+</header>
+
+<section class="main-content__body">
+  <form method="get" action="<%= admin_user_lookup_index_path %>" style="margin-bottom: 2rem; display: flex; align-items: center; gap: 1rem;">
+    <label for="email" style="font-weight: bold;">Email:</label>
+    <input type="text" name="email" id="email" value="<%= @email_query %>" placeholder="user@example.com" style="padding: 0.5rem; min-width: 300px;">
+    <button type="submit" style="padding: 0.5rem 1rem; background: #4f46e5; color: white; border: none; border-radius: 4px; cursor: pointer;">Search</button>
+  </form>
+
+  <% if @email_query.present? && @user.nil? %>
+    <p style="color: #ef4444;">No user found for "<%= @email_query %>".</p>
+  <% end %>
+
+  <% if @user.nil? && @latest_active_users.present? %>
+    <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 2rem;">
+      <h2 style="margin-top: 0; font-size: 1.25rem; color: #1e293b;">Latest Active Users</h2>
+      <p style="color: #64748b; font-size: 0.875rem; margin-top: 0.25rem;">Top 20 users by most recent API request.</p>
+      <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+        <thead>
+          <tr style="border-bottom: 2px solid #e2e8f0;">
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Email</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Last Activity</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @latest_active_users.each do |active_user, last_activity| %>
+            <tr style="border-bottom: 1px solid #e2e8f0;">
+              <td style="padding: 0.5rem;"><%= active_user.email %></td>
+              <td style="padding: 0.5rem;"><%= l(last_activity, format: :long) %></td>
+              <td style="padding: 0.5rem;"><%= link_to "Look up", admin_user_lookup_index_path(email: active_user.email), class: "navigation__link" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+
+  <% if @user %>
+    <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 2rem;">
+      <h2 style="margin-top: 0; font-size: 1.25rem; color: #1e293b;">
+        <%= @user.email %>
+      </h2>
+      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem;">
+        <div>
+          <span style="color: #64748b; font-size: 0.875rem;">ID</span><br>
+          <span style="font-family: monospace; font-size: 0.8rem;"><%= @user.id %></span>
+        </div>
+        <div>
+          <span style="color: #64748b; font-size: 0.875rem;">Admin</span><br>
+          <strong><%= @user.admin? ? "Yes" : "No" %></strong>
+        </div>
+        <div>
+          <span style="color: #64748b; font-size: 0.875rem;">OAuth</span><br>
+          <%= @user.oauth_provider || "—" %>
+        </div>
+        <div>
+          <span style="color: #64748b; font-size: 0.875rem;">Created at</span><br>
+          <%= l(@user.created_at, format: :long) %>
+        </div>
+        <div>
+          <span style="color: #64748b; font-size: 0.875rem;">Updated at</span><br>
+          <%= l(@user.updated_at, format: :long) %>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 1rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; margin-bottom: 2rem;">
+      <div>
+        <span style="color: #64748b; font-size: 0.875rem;">API Logs</span><br>
+        <strong style="font-size: 1.25rem; color: #1e293b;"><%= @api_request_logs.size %></strong>
+      </div>
+      <div>
+        <span style="color: #64748b; font-size: 0.875rem;">Last API Activity</span><br>
+        <strong style="color: #1e293b;"><%= @last_api_activity ? l(@last_api_activity, format: :long) : "—" %></strong>
+      </div>
+      <div>
+        <span style="color: #64748b; font-size: 0.875rem;">Inactive Days</span><br>
+        <% if @inactive_days %>
+          <strong style="font-size: 1.25rem; color: <%= @inactive_days > 30 ? '#ef4444' : @inactive_days > 7 ? '#f59e0b' : '#1e293b' %>;"><%= @inactive_days %></strong>
+        <% else %>
+          <strong style="color: #1e293b;">—</strong>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @api_request_logs.empty? %>
+      <p style="color: #64748b;">No API request logs.</p>
+    <% else %>
+      <p style="color: #64748b; font-size: 0.875rem; margin-bottom: 0.5rem;">Showing latest 200</p>
+      <table style="width: 100%; border-collapse: collapse;">
+        <thead>
+          <tr style="border-bottom: 2px solid #e2e8f0;">
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Started at</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Method</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Endpoint</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Status</th>
+            <th style="text-align: right; padding: 0.5rem; color: #64748b;">Duration (ms)</th>
+            <th style="text-align: left; padding: 0.5rem; color: #64748b;">Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @api_request_logs.each do |log| %>
+            <% row_style = log.response_code.to_s.start_with?("2") ? "" : "color: #ef4444;" %>
+            <tr style="border-bottom: 1px solid #e2e8f0; <%= row_style %>">
+              <td style="padding: 0.5rem;"><%= l(log.started_at, format: :long) %></td>
+              <td style="padding: 0.5rem;"><%= log.http_method %></td>
+              <td style="padding: 0.5rem;"><%= log.endpoint %></td>
+              <td style="padding: 0.5rem;"><%= log.response_code %></td>
+              <td style="padding: 0.5rem; text-align: right;"><%= log.duration_ms %></td>
+              <td style="padding: 0.5rem;"><%= link_to "View", admin_api_request_log_path(log), class: "navigation__link" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% end %>
+</section>

--- a/backend/config/initializers/api_request_logger_middleware.rb
+++ b/backend/config/initializers/api_request_logger_middleware.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require Rails.root.join("app/middleware/api_request_logger_middleware")
+
+Rails.application.config.middleware.use ApiRequestLoggerMiddleware

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,17 @@ require "sidekiq/web"
 
 Rails.application.routes.draw do
   namespace :admin do
+    resources :daily_overview, only: [:index]
+    resources :user_lookup, only: [:index]
+    resources :requests_dashboard, only: [:index]
+    resources :user_analytics, only: [:index]
+    resources :api_error_logs, only: [:index]
+    resources :request_logs_by_payload, only: [:index] do
+      collection do
+        get :details
+      end
+    end
+    resources :api_request_logs
     resources :users
 
     root to: "users#index"

--- a/backend/db/migrate/20260302000001_enable_pgcrypto.rb
+++ b/backend/db/migrate/20260302000001_enable_pgcrypto.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnablePgcrypto < ActiveRecord::Migration[8.1]
+  def change
+    enable_extension "pgcrypto"
+  end
+end

--- a/backend/db/migrate/20260302000002_migrate_users_to_uuid_pk.rb
+++ b/backend/db/migrate/20260302000002_migrate_users_to_uuid_pk.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MigrateUsersToUuidPk < ActiveRecord::Migration[8.1]
+  def up
+    change_table :users, bulk: true do |t|
+      t.column :uuid_id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    end
+
+    change_table :users, bulk: true do |t|
+      t.remove :id
+    end
+
+    # rubocop:disable Rails/DangerousColumnNames
+    rename_column :users, :uuid_id, :id
+    # rubocop:enable Rails/DangerousColumnNames
+
+    execute "ALTER TABLE users ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20260302000003_migrate_devise_api_tokens_to_uuid.rb
+++ b/backend/db/migrate/20260302000003_migrate_devise_api_tokens_to_uuid.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class MigrateDeviseApiTokensToUuid < ActiveRecord::Migration[8.1]
+  def up
+    # All existing tokens are invalidated because resource_owner_id (bigint)
+    # can no longer map to users.id (now uuid). Users must re-authenticate.
+    execute "TRUNCATE devise_api_tokens;"
+
+    # Add uuid PK column and change resource_owner_id type
+    change_table :devise_api_tokens, bulk: true do |t|
+      t.column :uuid_id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+      t.remove :resource_owner_id
+      # rubocop:disable Rails/NotNullColumn
+      t.column :resource_owner_id, :uuid, null: false
+      # rubocop:enable Rails/NotNullColumn
+      t.remove :id
+    end
+
+    # rubocop:disable Rails/DangerousColumnNames
+    rename_column :devise_api_tokens, :uuid_id, :id
+    # rubocop:enable Rails/DangerousColumnNames
+    execute "ALTER TABLE devise_api_tokens ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20260302000004_migrate_versions_item_id_to_string.rb
+++ b/backend/db/migrate/20260302000004_migrate_versions_item_id_to_string.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MigrateVersionsItemIdToString < ActiveRecord::Migration[8.1]
+  def up
+    # Clear historical version data; old bigint item_ids no longer map to any record
+    execute "TRUNCATE versions;"
+
+    change_table :versions, bulk: true do |t|
+      # Change item_id from bigint to string (PaperTrail UUID support)
+      t.change :item_id, :string, null: false
+      t.column :uuid_id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+      t.remove :id
+    end
+
+    # rubocop:disable Rails/DangerousColumnNames
+    rename_column :versions, :uuid_id, :id
+    # rubocop:enable Rails/DangerousColumnNames
+    execute "ALTER TABLE versions ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20260319100000_create_api_request_logs.rb
+++ b/backend/db/migrate/20260319100000_create_api_request_logs.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateApiRequestLogs < ActiveRecord::Migration[8.1]
+  # rubocop:disable Metrics/MethodLength
+  def change
+    create_table :api_request_logs, id: :uuid do |t|
+      t.references :user, type: :uuid, null: true, foreign_key: true
+      t.string :http_method, null: false
+      t.string :endpoint, null: false
+      t.jsonb :headers, null: false, default: {}
+      t.jsonb :payload, null: false, default: {}
+      t.jsonb :response, null: false, default: {}
+      t.datetime :started_at, null: false
+      t.datetime :ended_at, null: false
+      t.integer :duration_ms, null: false
+
+      t.index :started_at
+      t.index :endpoint
+      t.timestamps
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/backend/db/migrate/20260319101000_add_deleted_at_to_api_request_logs.rb
+++ b/backend/db/migrate/20260319101000_add_deleted_at_to_api_request_logs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToApiRequestLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :api_request_logs, :deleted_at, :datetime
+    add_index :api_request_logs, :deleted_at
+  end
+end

--- a/backend/db/migrate/20260319102000_add_response_code_to_api_request_logs.rb
+++ b/backend/db/migrate/20260319102000_add_response_code_to_api_request_logs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddResponseCodeToApiRequestLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :api_request_logs, :response_code, :integer, null: false, default: 0
+    add_index :api_request_logs, :response_code
+  end
+end

--- a/backend/db/migrate/20260319110000_add_name_to_users.rb
+++ b/backend/db/migrate/20260319110000_add_name_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :name, :string, limit: 200
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,32 +10,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_05_26_124316) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_19_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
 
-  create_table "devise_api_tokens", force: :cascade do |t|
+  create_table "api_request_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at"
+    t.integer "duration_ms", null: false
+    t.datetime "ended_at", null: false
+    t.string "endpoint", null: false
+    t.jsonb "headers", default: {}, null: false
+    t.string "http_method", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.jsonb "response", default: {}, null: false
+    t.integer "response_code", default: 0, null: false
+    t.datetime "started_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["deleted_at"], name: "index_api_request_logs_on_deleted_at"
+    t.index ["endpoint"], name: "index_api_request_logs_on_endpoint"
+    t.index ["response_code"], name: "index_api_request_logs_on_response_code"
+    t.index ["started_at"], name: "index_api_request_logs_on_started_at"
+    t.index ["user_id"], name: "index_api_request_logs_on_user_id"
+  end
+
+  create_table "devise_api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "access_token", null: false
     t.datetime "created_at", null: false
     t.integer "expires_in", null: false
     t.string "previous_refresh_token"
     t.string "refresh_token"
-    t.bigint "resource_owner_id", null: false
+    t.uuid "resource_owner_id", null: false
     t.string "resource_owner_type", null: false
     t.datetime "revoked_at"
     t.datetime "updated_at", null: false
     t.index ["access_token"], name: "index_devise_api_tokens_on_access_token"
     t.index ["previous_refresh_token"], name: "index_devise_api_tokens_on_previous_refresh_token"
     t.index ["refresh_token"], name: "index_devise_api_tokens_on_refresh_token"
-    t.index ["resource_owner_type", "resource_owner_id"], name: "index_devise_api_tokens_on_resource_owner"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "name", limit: 200
     t.string "oauth_provider"
     t.string "oauth_uid"
     t.datetime "remember_created_at"
@@ -47,13 +69,15 @@ ActiveRecord::Schema[8.1].define(version: 2024_05_26_124316) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", force: :cascade do |t|
+  create_table "versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at"
     t.string "event", null: false
-    t.bigint "item_id", null: false
+    t.string "item_id", null: false
     t.string "item_type", null: false
     t.text "object"
     t.string "whodunnit"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
+
+  add_foreign_key "api_request_logs", "users"
 end

--- a/backend/spec/factories/api_request_logs.rb
+++ b/backend/spec/factories/api_request_logs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_request_log do
+    user
+    http_method { "GET" }
+    endpoint { "/api/v1/users" }
+    response_code { 200 }
+    started_at { Time.current }
+    ended_at { 0.1.seconds.from_now }
+    duration_ms { 100 }
+  end
+end

--- a/backend/spec/middleware/api_request_logger_middleware_spec.rb
+++ b/backend/spec/middleware/api_request_logger_middleware_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiRequestLoggerMiddleware do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(_env) { [200, { "Content-Type" => "application/json" }, ["{}"]] } }
+
+  describe "private fallback branches" do
+    it "stores raw payload when content-type is json but body is invalid json" do
+      env = Rack::MockRequest.env_for(
+        "/api/v1/test",
+        method: "POST",
+        "CONTENT_TYPE" => "application/json",
+        input: "{invalid-json"
+      )
+      request = ActionDispatch::Request.new(env)
+
+      expect(middleware.send(:parse_body, request)).to eq(raw: "{invalid-json")
+    end
+
+    it "returns nil body when response body is blank" do
+      payload = middleware.send(:build_response_payload, 204, "")
+
+      expect(payload).to eq(status: 204, body: nil)
+    end
+
+    it "stores raw response when response body is not json" do
+      payload = middleware.send(:build_response_payload, 200, "plain text response")
+
+      expect(payload).to eq(status: 200, body: "plain text response")
+    end
+  end
+end

--- a/backend/spec/requests/admin/api_error_logs_spec.rb
+++ b/backend/spec/requests/admin/api_error_logs_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::ApiErrorLogs" do
+  describe "GET /admin/api_error_logs" do
+    context "when not authenticated" do
+      before { get "/admin/api_error_logs" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/api_error_logs"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+      let(:target_user) { create(:user) }
+      let(:t0) { Time.zone.parse("2026-03-23 10:00:00") }
+      let(:travel_time) { Time.zone.parse("2026-04-01 12:00:00") }
+
+      before do
+        sign_in admin
+        travel_to travel_time
+      end
+
+      context "with no non-2xx logs" do
+        before { get "/admin/api_error_logs" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("No non-2xx API request logs found.") }
+      end
+
+      context "with non-2xx logs" do
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/old", response_code: 500,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "POST",
+            endpoint: "/api/v1/newer", response_code: 404,
+            started_at: t0 + 2.hours, ended_at: t0 + 2.hours + 1.second, duration_ms: 50
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/older-404", response_code: 404,
+            started_at: t0 + 1.hour, ended_at: t0 + 1.hour + 1.second, duration_ms: 75
+          )
+          get "/admin/api_error_logs"
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+
+        it "orders groups by most recent activity first" do
+          pos_404 = response.body.index("HTTP 404")
+          pos_500 = response.body.index("HTTP 500")
+          expect(pos_404).to be < pos_500
+        end
+
+        it "orders rows within a group newest first" do
+          newer = response.body.index("/api/v1/newer")
+          older = response.body.index("/api/v1/older-404")
+          expect(newer).to be < older
+        end
+
+        it "includes administrate detail links" do
+          log = ApiRequestLog.find_by(endpoint: "/api/v1/newer")
+          expect(response.body).to include(admin_api_request_log_path(log))
+        end
+      end
+
+      context "with filters" do
+        let(:other_user) { create(:user, email: "someone.else@example.com") }
+
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/match", response_code: 500,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: other_user, http_method: "GET",
+            endpoint: "/api/v1/other-user", response_code: 500,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/old-date", response_code: 500,
+            started_at: t0 - 10.days, ended_at: t0 - 10.days + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/new-date", response_code: 500,
+            started_at: t0 + 10.days, ended_at: t0 + 10.days + 1.second, duration_ms: 100
+          )
+        end
+
+        it "filters by partial user email (ILIKE)" do
+          get "/admin/api_error_logs", params: { email: target_user.email.split("@").first }
+          expect(response.body).to include("/api/v1/match")
+          expect(response.body).not_to include("/api/v1/other-user")
+        end
+
+        it "filters case-insensitively by email" do
+          get "/admin/api_error_logs", params: { email: target_user.email.upcase }
+          expect(response.body).to include("/api/v1/match")
+          expect(response.body).not_to include("/api/v1/other-user")
+        end
+
+        it "filters by start_date (inclusive)" do
+          get "/admin/api_error_logs", params: { start_date: t0.to_date.iso8601 }
+          expect(response.body).to include("/api/v1/match")
+          expect(response.body).to include("/api/v1/new-date")
+          expect(response.body).not_to include("/api/v1/old-date")
+        end
+
+        it "filters by end_date (inclusive)" do
+          get "/admin/api_error_logs", params: { end_date: t0.to_date.iso8601 }
+          expect(response.body).to include("/api/v1/match")
+          expect(response.body).to include("/api/v1/old-date")
+          expect(response.body).not_to include("/api/v1/new-date")
+        end
+
+        it "combines email + date range filters" do
+          get "/admin/api_error_logs", params: {
+            email: target_user.email,
+            start_date: t0.to_date.iso8601,
+            end_date: t0.to_date.iso8601
+          }
+          aggregate_failures do
+            expect(response.body).to include("/api/v1/match")
+            expect(response.body).not_to include("/api/v1/other-user")
+            expect(response.body).not_to include("/api/v1/old-date")
+            expect(response.body).not_to include("/api/v1/new-date")
+          end
+        end
+
+        it "ignores invalid date strings without raising" do
+          get "/admin/api_error_logs", params: { start_date: "not-a-date", end_date: "also-bad" }
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("/api/v1/match")
+        end
+
+        it "renders the Clear link when filters are active" do
+          get "/admin/api_error_logs", params: { email: "gmail" }
+          expect(response.body).to include(">Clear</a>")
+        end
+
+        it "renders the Clear link by default since date defaults are always applied" do
+          get "/admin/api_error_logs"
+          expect(response.body).to include(">Clear</a>")
+        end
+
+        it "renders the Clear link when only the app_version filter is active" do
+          get "/admin/api_error_logs", params: { app_version: "1.2.3" }
+          expect(response.body).to include(">Clear</a>")
+        end
+      end
+
+      context "with default date filters" do
+        before { get "/admin/api_error_logs" }
+
+        it "preselects from = 30 days ago" do
+          expected = (travel_time.to_date - 30).iso8601
+          expect(response.body).to include(%(value="#{expected}"))
+        end
+
+        it "preselects to = tomorrow" do
+          expected = (travel_time.to_date + 1).iso8601
+          expect(response.body).to include(%(value="#{expected}"))
+        end
+      end
+
+      context "with chart axis covering the full date range" do
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/just-one", response_code: 500,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100
+          )
+          get "/admin/api_error_logs", params: {
+            start_date: "2026-03-20", end_date: "2026-03-25"
+          }
+        end
+
+        it "includes every day in the selected range as a chart label" do
+          %w[2026-03-20 2026-03-21 2026-03-22 2026-03-23 2026-03-24 2026-03-25].each do |day|
+            expect(response.body).to include(day)
+          end
+        end
+      end
+
+      context "with logs from multiple app versions" do
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/from-1-2-3", response_code: 500,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100,
+            headers: { "App-Version" => "1.2.3" }
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/from-1-2-4", response_code: 500,
+            started_at: t0 + 1.hour, ended_at: t0 + 1.hour + 1.second, duration_ms: 100,
+            headers: { "App-Version" => "1.2.4" }
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/from-unknown", response_code: 500,
+            started_at: t0 + 2.hours, ended_at: t0 + 2.hours + 1.second, duration_ms: 100,
+            headers: {}
+          )
+        end
+
+        it "renders an option for each known app version plus 'unknown'" do
+          get "/admin/api_error_logs"
+
+          expect(response.body).to include('<option value="1.2.3"')
+          expect(response.body).to include('<option value="1.2.4"')
+          expect(response.body).to include('<option value="unknown"')
+        end
+
+        it "filters logs to a specific app version" do
+          get "/admin/api_error_logs", params: { app_version: "1.2.3" }
+
+          expect(response.body).to include("/api/v1/from-1-2-3")
+          expect(response.body).not_to include("/api/v1/from-1-2-4")
+          expect(response.body).not_to include("/api/v1/from-unknown")
+        end
+
+        it "filters to logs without an App-Version header when 'unknown' is selected" do
+          get "/admin/api_error_logs", params: { app_version: "unknown" }
+
+          expect(response.body).to include("/api/v1/from-unknown")
+          expect(response.body).not_to include("/api/v1/from-1-2-3")
+          expect(response.body).not_to include("/api/v1/from-1-2-4")
+        end
+
+        it "preselects the chosen app version in the dropdown" do
+          get "/admin/api_error_logs", params: { app_version: "1.2.4" }
+
+          expect(response.body).to include('<option value="1.2.4" selected>1.2.4</option>')
+        end
+
+        it "shows a clear-filter badge when filtered" do
+          get "/admin/api_error_logs", params: { app_version: "1.2.3" }
+
+          expect(response.body).to include("Filtered: 1.2.3")
+        end
+
+        it "shows a filter-aware empty-state message when nothing matches" do
+          get "/admin/api_error_logs", params: { app_version: "9.9.9" }
+
+          expect(response.body).to include("No non-2xx API request logs found for app version 9.9.9.")
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/admin/daily_overview_spec.rb
+++ b/backend/spec/requests/admin/daily_overview_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::DailyOverview" do
+  describe "GET /admin/daily_overview" do
+    context "when not authenticated" do
+      before { get "/admin/daily_overview" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/daily_overview"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+
+      before { sign_in admin }
+
+      context "without params" do
+        before { get "/admin/daily_overview" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("Daily Overview") }
+        it { expect(response.body).to include("Users") }
+        it { expect(response.body).to include("API Request Logs") }
+
+        it "renders one chart canvas per tracked entity" do
+          %w[users api-request-logs].each do |slug|
+            expect(response.body).to include(%(id="chart-#{slug}"))
+          end
+        end
+      end
+
+      context "with days param" do
+        before { get "/admin/daily_overview", params: { days: 7 } }
+
+        it { expect(response).to have_http_status(:ok) }
+      end
+
+      context "with out-of-range days param" do
+        before { get "/admin/daily_overview", params: { days: 9999 } }
+
+        it { expect(response).to have_http_status(:ok) }
+      end
+
+      context "with data across entities" do
+        let(:user) { create(:user) }
+
+        before do
+          travel_to Time.zone.parse("2026-03-15 12:00:00") do
+            create(
+              :api_request_log, user: user, created_at: Time.current, started_at: Time.current,
+              ended_at: 1.second.from_now
+            )
+            get "/admin/daily_overview"
+          end
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+      end
+    end
+  end
+end

--- a/backend/spec/requests/admin/request_logs_by_payload_spec.rb
+++ b/backend/spec/requests/admin/request_logs_by_payload_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::RequestLogsByPayload" do
+  describe "GET /admin/request_logs_by_payload" do
+    context "when not authenticated" do
+      before { get "/admin/request_logs_by_payload" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/request_logs_by_payload"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+      let(:target_user) { create(:user, email: "doctor@example.com") }
+      let(:t0) { 2.days.ago.change(hour: 10) }
+
+      before { sign_in admin }
+
+      context "with no non-2xx logs" do
+        before { get "/admin/request_logs_by_payload" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("No non-2xx API request logs found.") }
+      end
+
+      context "with non-2xx logs" do
+        let(:payload) { { "key" => "value" } }
+
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "POST",
+            endpoint: "/api/v1/users", response_code: 422,
+            payload: payload, headers: { "App-Version" => "1.4.2" },
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "POST",
+            endpoint: "/api/v1/users", response_code: 500,
+            payload: payload, headers: { "App-Version" => "1.4.2" },
+            started_at: t0 + 1.hour, ended_at: t0 + 1.hour + 1.second, duration_ms: 50
+          )
+          get "/admin/request_logs_by_payload"
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+
+        it "displays the daily totals section" do
+          expect(response.body).to include("Total non-2xx requests per day")
+        end
+
+        it "displays the grouped logs section" do
+          expect(response.body).to include("Grouped by payload, response code, day, and user")
+        end
+
+        it "shows the user email" do
+          expect(response.body).to include("doctor@example.com")
+        end
+
+        it "shows the payload content" do
+          expect(response.body).to include("value")
+        end
+
+        it "shows an App version column header" do
+          expect(response.body).to include("App version")
+        end
+
+        it "shows the App-Version from the request headers in the grouped table" do
+          expect(response.body).to include("1.4.2")
+        end
+      end
+
+      context "with logs older than 10 days" do
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/old", response_code: 500,
+            started_at: 15.days.ago, ended_at: 15.days.ago + 1.second, duration_ms: 100
+          )
+          get "/admin/request_logs_by_payload"
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+
+        it "does not show old logs" do
+          expect(response.body).to include("No non-2xx API request logs found.")
+        end
+      end
+
+      context "with 2xx logs only" do
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/users", response_code: 200,
+            started_at: t0, ended_at: t0 + 1.second, duration_ms: 50
+          )
+          get "/admin/request_logs_by_payload"
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+
+        it "does not show 2xx logs" do
+          expect(response.body).to include("No non-2xx API request logs found.")
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/admin/requests_dashboard_spec.rb
+++ b/backend/spec/requests/admin/requests_dashboard_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::RequestsDashboard" do
+  describe "GET /admin/requests_dashboard" do
+    context "when not authenticated" do
+      before { get "/admin/requests_dashboard" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/requests_dashboard"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+
+      before { sign_in admin }
+
+      context "without user_id param" do
+        before { get "/admin/requests_dashboard" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("Search by email") }
+        it { expect(response.body).to include("or pick user") }
+      end
+
+      context "with email param matching a user" do
+        let(:target_user) { create(:user, email: "needle@example.com") }
+
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/needle", response_code: 200,
+            started_at: 1.hour.ago, ended_at: 1.hour.ago + 1.second, duration_ms: 50
+          )
+          get "/admin/requests_dashboard", params: { email: "needle" }
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include(target_user.email) }
+        it { expect(response.body).to include("/api/v1/needle") }
+      end
+
+      context "with email param matching no user" do
+        before { get "/admin/requests_dashboard", params: { email: "nobody@example.com" } }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include('No user matched "nobody@example.com"') }
+      end
+
+      context "with user_id param" do
+        let(:target_user) { create(:user) }
+        let(:now) { Time.zone.parse("2026-03-23 10:00:00") }
+
+        before do
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/users", response_code: 200,
+            started_at: now, ended_at: now + 1.second, duration_ms: 100
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "GET",
+            endpoint: "/api/v1/users", response_code: 200,
+            started_at: now + 1.hour, ended_at: now + 1.hour + 1.second, duration_ms: 150
+          )
+          create(
+            :api_request_log, user: target_user, http_method: "POST",
+            endpoint: "/api/v1/users", response_code: 500,
+            started_at: now + 2.hours, ended_at: now + 2.hours + 1.second, duration_ms: 200
+          )
+          get "/admin/requests_dashboard", params: { user_id: target_user.id }
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("2xx Requests") }
+        it { expect(response.body).to include("Non-2xx Requests") }
+        it { expect(response.body).to include(target_user.email) }
+
+        it "shows grouped request counts" do
+          expect(response.body).to include("/api/v1/users")
+        end
+
+        it "shows non-2xx requests in error table" do
+          expect(response.body).to include("500")
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/admin/user_analytics_spec.rb
+++ b/backend/spec/requests/admin/user_analytics_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::UserAnalytics" do
+  describe "GET /admin/user_analytics" do
+    context "when not authenticated" do
+      before { get "/admin/user_analytics" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/user_analytics"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+
+      before { sign_in admin }
+
+      context "without date params" do
+        before { get "/admin/user_analytics" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("User Analytics") }
+        it { expect(response.body).to include("Total Users") }
+        it { expect(response.body).to include("growthChart") }
+      end
+
+      context "with date params" do
+        before do
+          get "/admin/user_analytics", params: { start_date: 7.days.ago.to_date.to_s, end_date: Date.current.to_s }
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("User Analytics") }
+      end
+
+      context "with users created across days" do
+        before do
+          create(:user, created_at: 2.days.ago)
+          create(:user, created_at: 1.day.ago)
+          get "/admin/user_analytics"
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+
+        it "includes the total user count" do
+          expect(response.body).to include(User.count.to_s)
+        end
+      end
+
+      context "with invalid date params" do
+        before do
+          get "/admin/user_analytics", params: { start_date: "invalid", end_date: "also-invalid" }
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+      end
+    end
+  end
+end

--- a/backend/spec/requests/admin/user_lookup_spec.rb
+++ b/backend/spec/requests/admin/user_lookup_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::UserLookup" do
+  describe "GET /admin/user_lookup" do
+    context "when not authenticated" do
+      before { get "/admin/user_lookup" }
+
+      it { expect(response).to have_http_status(:redirect) }
+    end
+
+    context "when authenticated as non-admin" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get "/admin/user_lookup"
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context "when authenticated as admin" do
+      let(:admin) { create(:user, admin: true) }
+
+      before { sign_in admin }
+
+      context "without email param" do
+        before { get "/admin/user_lookup" }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("User Lookup") }
+      end
+
+      context "with latest active users panel" do
+        let!(:older_user) { create(:user, email: "older@example.com") }
+        let!(:newer_user) { create(:user, email: "newer@example.com") }
+
+        before do
+          create(
+            :api_request_log, user: older_user,
+            started_at: 2.days.ago, ended_at: 2.days.ago + 1.second, duration_ms: 50
+          )
+          create(
+            :api_request_log, user: newer_user,
+            started_at: 1.hour.ago, ended_at: 1.hour.ago + 1.second, duration_ms: 50
+          )
+          get "/admin/user_lookup"
+        end
+
+        it { expect(response.body).to include("Latest Active Users") }
+        it { expect(response.body).to include(older_user.email) }
+        it { expect(response.body).to include(newer_user.email) }
+
+        it "orders newer activity before older activity" do
+          expect(response.body.index(newer_user.email)).to be < response.body.index(older_user.email)
+        end
+      end
+
+      context "with email that does not match any user" do
+        before { get "/admin/user_lookup", params: { email: "nonexistent@email.com" } }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include("No user found") }
+      end
+
+      context "with email matching a user" do
+        let(:user) { create(:user) }
+
+        before do
+          create(
+            :api_request_log, user: user, http_method: "GET",
+            endpoint: "/api/v1/test", response_code: 200,
+            started_at: 1.hour.ago, ended_at: 1.hour.ago + 1.second, duration_ms: 100
+          )
+          get "/admin/user_lookup", params: { email: user.email }
+        end
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include(user.email) }
+        it { expect(response.body).to include("API Logs") }
+        it { expect(response.body).to include("Last API Activity") }
+        it { expect(response.body).to include("Inactive Days") }
+        it { expect(response.body).to include("/api/v1/test") }
+      end
+
+      context "with case-insensitive email search" do
+        let(:user) { create(:user) }
+
+        before { get "/admin/user_lookup", params: { email: user.email.upcase } }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to include(user.email) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backports the request-logging middleware, admin observability dashboards, and generic User improvements (UUID PK, `name` column) from the [plantao backend](https://github.com/roandersonpinheiro/plantao) into this boilerplate. Plantao-specific business code (medical_shifts, locations, chat_messages, domain_events, app_versions, doctor/accountant roles, Firebase auth, paying flag, mobile_platform, etc.) is intentionally **not** brought over. Existing boilerplate features (GraphQL, Chewy, Schools, HandleFile, demo_pack, oauth pack) are untouched.

### What's added

- **Migrations (8)**: enable `pgcrypto`, convert `users.id` and `devise_api_tokens` to UUID, change `versions.item_id` to string for PaperTrail compatibility with UUID records, add `name` to users, create `api_request_logs` (with `deleted_at` + `response_code`).
- **`ApiRequestLog` model** with `summary` helper; `User` gains `has_many :api_request_logs`.
- **`ApiRequestLoggerMiddleware`** records every `/api/*` request to `api_request_logs` and resolves the user via the Bearer access token.
- **Admin dashboards under `/admin`** — Administrate CRUD for ApiRequestLog plus six custom dashboards: Daily Overview, Requests Dashboard, Non-2xx API Logs, User Analytics, User Lookup, Request Logs by Payload. Dashboards that originally referenced removed plantao entities have been adapted to track only User and ApiRequestLog data.
- **Routes**: new `admin` resources for the seven dashboards above.
- **Specs**: factory + middleware spec + six admin request specs (99 examples, 0 failures), conforming to this repo's stricter RuboCop config.
- **CLAUDE.md**: short note on the new middleware + dashboards.

### Heads-up: UUID migration is destructive

Migrating `users` from bigint to UUID truncates `devise_api_tokens` (existing tokens become invalid) and `versions` (PaperTrail history is cleared). Any deployment with real data on a fork of this branch will need a coordinated re-auth + acceptance of the lost audit trail.

## Test plan

- [ ] `bin/rails db:drop db:create db:migrate` runs cleanly; `db/schema.rb` shows `users.id`, `devise_api_tokens.id` + `resource_owner_id`, `versions.id` as UUID and `versions.item_id` as string.
- [ ] `bundle exec bin/rspec -P './*/**/*_spec.rb'` passes without any new regressions.
- [ ] `bundle exec rubocop` reports no new offenses.
- [ ] Manual smoke: create a user via `POST /api/v1/users`, sign in via `POST /api/v1/tokens`, hit `GET /api/v1/users` with the bearer token, and confirm a corresponding row appears in `api_request_logs`.
- [ ] Sign in to `/admin` as `admin@email.com / password` (after `bin/rails db:seed`) and click through every nav entry — each dashboard should render without errors.
- [ ] Hit `/api/v1/users` without a token and verify the resulting 401 shows up under `/admin/api_error_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)