### PR TITLE
Restore 'database' DNS alias on the postgres compose service

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -39,6 +39,10 @@ services:
     healthcheck:
       test: pg_isready -U postgres -h 127.0.0.1
       interval: 5s
+    networks:
+      default:
+        aliases:
+          - database
   elasticsearch:
     image: elasticsearch:8.10.2
     environment:


### PR DESCRIPTION
## Summary

The \`database\` service in \`backend/docker-compose.yml\` declares \`hostname: database-app-container\`. On some Docker / Compose / DNS resolver combinations, that explicit hostname is registered as the *only* DNS name on the network — the default service-name alias gets dropped — so \`web\` and \`sidekiq\` containers can no longer resolve \`database\`, the value the \`.env\` file (and \`config/database.yml\`) expects.

This adds an explicit \`networks.default.aliases\` entry so both \`database\` and \`database-app-container\` resolve to the same container, regardless of how the DNS layer behaves. \`redis\` and \`elasticsearch\` are unaffected — \`redis\` already happens to use its service name as the hostname, and \`elasticsearch\` has no \`hostname:\` line so it picks up the default alias automatically.

## Test plan

- [ ] \`docker compose up -d\` (no other env tweaks)
- [ ] \`docker compose exec web getent hosts database\` returns an IP
- [ ] \`docker compose exec web getent hosts database-app-container\` returns the same IP
- [ ] \`docker compose exec web bin/rails db:migrate\` connects successfully without setting \`POSTGRES_HOST\` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)